### PR TITLE
Remove listeners on instance alive status on instance removal

### DIFF
--- a/server/proxies/manager/index.js
+++ b/server/proxies/manager/index.js
@@ -128,11 +128,13 @@ module.exports = class Manager extends EventEmitter {
 
                 instance.on('alive:updated', (alive) => {
                     const name = instance.name;
-                    if (alive) {
+                    if (alive && !instance.removing) {
                         self._aliveInstances.push(instance);
                         self._aliveInstancesMap.set(name, instance);
                     }
                     else {
+                        // If instance is not alive OR instance is alived but is asked to be removed
+                        // we remove the instance from the alive pool
                         const idx = self._aliveInstances.indexOf(instance);
                         if (idx >= 0) {
                             self._aliveInstances.splice(idx, 1);

--- a/server/proxies/manager/instance.js
+++ b/server/proxies/manager/instance.js
@@ -20,6 +20,7 @@ module.exports = class Instance extends EventEmitter {
         self._config = config;
 
         self._model = void 0;
+        self._removing = false;
         self._alive = false;
         self._aliveCount = void 0;
         self._rqCount = 0;
@@ -205,6 +206,11 @@ module.exports = class Instance extends EventEmitter {
     }
 
 
+    get removing() {
+        return this._removing;
+    }
+
+
     removedFromManager() {
         this._model.status = InstanceModel.REMOVED;
 
@@ -213,6 +219,7 @@ module.exports = class Instance extends EventEmitter {
 
 
     remove() {
+        this._removing = true;
         this._changeAlive(false);
 
         return this._provider.removeInstance(this._model);


### PR DESCRIPTION
Remove a source of ghost instance. There are several ways to solve this, I can suggest this one but you might prefer checking in `getNextRunningInstance` that an instance is alive and managed.