### PR TITLE
Added blocklist functionality to scrapoxy

### DIFF
--- a/docs/standard/config/index.rst
+++ b/docs/standard/config/index.rst
@@ -158,12 +158,13 @@ Providers is an array of provider. It can contains multiple providers:
 Options: proxy
 ==============
 
-====== ============= ===================================================
-Option Default value Description
-====== ============= ===================================================
-port   8888          TCP port of Scrapoxy
-auth   none          see :ref:`proxy / auth <proxy-auth>` (optional)
-====== ============= ===================================================
+========= ============= ===================================================
+Option    Default value Description
+========= ============= ===================================================
+port      8888          TCP port of Scrapoxy
+auth      none          see :ref:`proxy / auth <proxy-auth>` (optional)
+blocklist []            Rules of urls (or parts of urls) that are not allowed to be requested. Scrapoxy will reject the request if the URL contains anything from the blocklist.
+========= ============= ===================================================
 
 
 .. _proxy-auth:

--- a/server/config.defaults.js
+++ b/server/config.defaults.js
@@ -5,6 +5,7 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'; // Allow wrong certificates
 module.exports = {
     proxy: {
         port: 8888,
+        blocklist: [], // if anything defined in blocklist is found in requested URL, Master will reject.
     },
 
     commander: {

--- a/server/proxies/master/index.js
+++ b/server/proxies/master/index.js
@@ -38,7 +38,7 @@ module.exports = class Master {
         self._server = http.createServer();
 
         self._server.on('request', request);
-		self._server.on('connect', connect);
+        self._server.on('connect', connect);
 
 
         ////////////
@@ -52,6 +52,13 @@ module.exports = class Master {
                         'Proxy-Authenticate': 'Basic realm="Scrapoxy"',
                         'Content-Type': 'text/plain',
                     });
+                }
+            }
+
+            // Check requested url against blocklist items
+            for (var blockrule of self._config.blocklist) {
+                if (req.url.indexOf(blockrule) !== -1) {
+                    return writeEnd(res, 403, '[Master] Error: Requested URL matches blocklist rule');
                 }
             }
 
@@ -179,6 +186,13 @@ module.exports = class Master {
                         'Proxy-Authenticate': 'Basic realm="Scrapoxy"',
                         'Connection': 'close',
                     });
+                }
+            }
+
+            // Check requested url against blocklist items
+            for (var blockrule of self._config.blocklist) {
+                if (req.url.indexOf(blockrule) !== -1) {
+                    return writeEnd(socket, 403, '[Master] Error: Requested URL matches blocklist rule');
                 }
             }
 


### PR DESCRIPTION
As discussed in https://github.com/fabienvauchelles/scrapoxy/issues/106

In configuration blocklist allows list of URLs (or fragments of URLs) to be specified, which Master will check against before continuing.

Block any url containing google/facebook
```
[
'google',
'facebook'
]
```

Block .co.uk URLs:
```
[
'.co.uk',
]
```

Block specific URL:
```
[
'https://www.example.com/sample-page',
]
```

@fabienvauchelles here you are =)
