### PR TITLE
Add HTTPS note to `x-cache-proxyname` header

### DIFF
--- a/docs/advanced/understand/index.rst
+++ b/docs/advanced/understand/index.rst
@@ -75,6 +75,7 @@ Scrapoxy adds to the response an HTTP header **x-cache-proxyname**.
 
 This header contains the name of the proxy.
 
+If you are using HTTPS in `HTTPS CONNECT/Tunnel Mode` Scrapoxy is unable to add this header since the traffic is encrypted.
 
 Can the scraper force the request to go through a specific proxy?
 -----------------------------------------------------------------


### PR DESCRIPTION
Can you confirm that this readme update is in fact correct and complete? I came across this situation today and am assuming this is what I was up against. I wished it had been in the docs.