### PR TITLE
fix(proxy): prevent process crash on invalid headers being sent

### DIFF
--- a/server/proxies/master/index.js
+++ b/server/proxies/master/index.js
@@ -130,7 +130,13 @@ module.exports = class Master {
                 proxy: instance.proxyParameters,
             });
 
-            const proxy_req = http.request(proxyOpts);
+            let proxy_req;
+            try {
+                proxy_req = http.request(proxyOpts);
+            } catch (error) {
+                return writeEndRequest(res, 500, `[Master] Error: Cannot create request (${error})`);
+            }
+
 
             proxy_req.on('error', (err) => {
                 winston.error('[Master] Error: request error from target (%s %s on instance %s):', req.method, req.url, instance.toString(), err);


### PR DESCRIPTION
When invalid headers are set, http.request method is raising a
TypeError, crashing the process. This fix catch errors raised on request
creation to prevent it.