### PR TITLE
Request Spot Instances from AWS EC2

### DIFF
--- a/server/providers/awsec2/index.js
+++ b/server/providers/awsec2/index.js
@@ -227,6 +227,13 @@ module.exports = class ProviderAWSEC2 {
                     MinCount: cnt,
                     MaxCount: cnt,
                     InstanceInitiatedShutdownBehavior: 'terminate',
+                    InstanceMarketOptions: {
+                        MarketType: "spot",
+                        SpotOptions:{
+                            InstanceInterruptionBehavior: "terminate",
+                            SpotInstanceType: "one-time"
+                        }
+                    },
                     Monitoring: {
                         Enabled: false,
                     },


### PR DESCRIPTION
This change requests spot instances instead of the default on-demand ones.

I know this project is dead, but I took some code from other PRs. Hopefully this one saves someone some time.