### PR TITLE
Add Azure spot instance and new instance types, also fix an issue when Azure is too slow to provision a VM

### DIFF
--- a/packages/backend/connectors/src/azure/azure.factory.ts
+++ b/packages/backend/connectors/src/azure/azure.factory.ts
@@ -56,6 +56,7 @@ import type {
 
 const FILTER_VM_SIZES = [
     'Standard_B1ls', 'Standard_B1s', 'Standard_B2s',
+    'Standard_A1_v2', 'Standard_D2plds_v5',
 ];
 
 

--- a/packages/backend/connectors/src/azure/azure.interface.ts
+++ b/packages/backend/connectors/src/azure/azure.interface.ts
@@ -32,6 +32,7 @@ export interface IConnectorAzureConfig {
     storageAccountType: string;
     prefix: string;
     imageResourceGroupName: string;
+    useSpotInstances: boolean;
 }
 
 
@@ -76,6 +77,9 @@ export interface IAzurePublicIpAddress extends IAzureResource {
     properties: {
         ipAddress?: string;
     };
+    tags: {
+        createdAt?: string;
+    }
 }
 
 

--- a/packages/backend/connectors/src/azure/azure.service.ts
+++ b/packages/backend/connectors/src/azure/azure.service.ts
@@ -98,7 +98,7 @@ export class ConnectorAzureService implements IConnectorService {
             this.connectorConfig.prefix,
             this.connectorConfig.port
         )
-            .addVms(namesLimit)
+            .addVms(namesLimit, this.connectorConfig.useSpotInstances)
             .build();
 
         await this.api.createDeployment(
@@ -123,6 +123,9 @@ export class ConnectorAzureService implements IConnectorService {
                         },
                         storageAccountType: {
                             value: this.connectorConfig.storageAccountType,
+                        },
+                        createdAt: {
+                            value: Math.floor(Date.now() / 1000).toString(),
                         },
                     },
                 },

--- a/packages/backend/connectors/src/azure/azure.validation.ts
+++ b/packages/backend/connectors/src/azure/azure.validation.ts
@@ -32,6 +32,7 @@ const schemaConfig = Joi.object({
     imageResourceGroupName: Joi.string()
         .pattern(azureNamePattern)
         .required(),
+    useSpotInstances: Joi.boolean().default(false),
 });
 
 

--- a/packages/backend/connectors/src/azure/state.ts
+++ b/packages/backend/connectors/src/azure/state.ts
@@ -133,6 +133,14 @@ export class AzureResourceGroupState {
         for (const name of this.networkInterfacesMap.keys()) {
             this.publicIpAddressesMap.delete(name);
         }
+
+        // Discard newly created IP
+        for (const name of this.publicIpAddressesMap.keys()) {
+            const ip = this.publicIpAddressesMap.get(name);
+            if((ip!.tags?.createdAt ?? 0) > (Math.floor(Date.now() / 1000)-180).toString()) {
+                this.publicIpAddressesMap.delete(name);
+            }
+        }
     }
 
     get disks(): IAzureDisk[] {

--- a/packages/backend/connectors/src/azure/tasks/install.task.ts
+++ b/packages/backend/connectors/src/azure/tasks/install.task.ts
@@ -138,6 +138,16 @@ class AzureInstallCommand extends ATaskCommand {
                 // Create VM reference
                 const installScript = await new InstallScriptBuilder(this.data.certificate)
                     .build();
+                let sku = '20_04-lts-gen2';
+
+                if (this.data.vmSize.startsWith('Standard_A1')) {
+                    sku = '20_04-lts';
+                }
+
+                if (this.data.vmSize.startsWith('Standard_D2pl')) {
+                    sku = '20_04-lts-arm64';
+                }
+
                 const template = new AzureVmsTemplateBuilder(
                     `${this.data.prefix}img`,
                     this.data.port
@@ -147,7 +157,7 @@ class AzureInstallCommand extends ATaskCommand {
                         {
                             publisher: 'canonical',
                             offer: '0001-com-ubuntu-server-focal',
-                            sku: '20_04-lts-gen2',
+                            sku,
                             version: 'latest',
                         },
                         installScript
@@ -169,6 +179,9 @@ class AzureInstallCommand extends ATaskCommand {
                                 },
                                 storageAccountType: {
                                     value: this.data.storageAccountType,
+                                },
+                                createdAt: {
+                                    value: Math.floor(Date.now() / 1000).toString(),
                                 },
                             },
                         },

--- a/packages/backend/test-connectors/src/azure.spec.ts
+++ b/packages/backend/test-connectors/src/azure.spec.ts
@@ -30,6 +30,7 @@ describe(
                 storageAccountType: AZURE_DEFAULT_STORAGE_ACCOUNT_TYPE,
                 prefix: `spxtest${suffix}`,
                 imageResourceGroupName: `spxtest_image_${suffix}_rg`,
+                useSpotInstances: false,
             },
             credentialConfigData = fs.readFileSync('packages/backend/test-connectors/src/assets/azure/credentials.json');
         const credentialConfig = JSON.parse(credentialConfigData.toString());

--- a/packages/frontend/connectors/src/azure/connector/connector.component.html
+++ b/packages/frontend/connectors/src/azure/connector/connector.component.html
@@ -116,6 +116,26 @@
             </c-col>
         </c-row>
     }
+    @if (subForm.controls['useSpotInstances']; as c) {
+        <c-row>
+            <label cLabel cCol md="2" for="useSpotInstances">Spot Instance</label>
+
+            <c-col md="10">
+                <c-input-group>
+                    
+                    <c-col md="8">
+                        <c-form-check [switch]="true" sizing="lg">
+                            <input
+                                type="checkbox"
+                                cFormCheckInput
+                                id="useSpotInstances"
+                                formControlName="useSpotInstances" />
+                        </c-form-check>
+                    </c-col>
+                </c-input-group>
+            </c-col>
+        </c-row>
+    }
     @if (subForm.controls['storageAccountType']; as c) {
         <c-row>
             <label cLabel cCol md="2" for="storageAccountType">Storage Type</label>

--- a/packages/frontend/connectors/src/azure/connector/connector.component.ts
+++ b/packages/frontend/connectors/src/azure/connector/connector.component.ts
@@ -82,6 +82,9 @@ export class ConnectorAzureComponent implements IConnectorComponent, OnInit {
             vmSize: [
                 void 0, Validators.required,
             ],
+            useSpotInstances: [
+                false, Validators.required,
+            ],
             storageAccountType: [
                 void 0, Validators.required,
             ],
@@ -115,6 +118,7 @@ export class ConnectorAzureComponent implements IConnectorComponent, OnInit {
                 storageAccountType: AZURE_DEFAULT_STORAGE_ACCOUNT_TYPE,
                 prefix: 'spx',
                 imageResourceGroupName: `${SCRAPOXY_DATACENTER_PREFIX}_image_rg`,
+                useSpotInstances: false,
             });
         }
 


### PR DESCRIPTION
# Changes

In this PR 2 changes are made:
- Add Spot instance and new instance size for Azure
- Add a delay of 180s before removing an unused IP

## Add Spot instance and new instance size for Azure
So basically, now we have the possibility to use `Standard_A1_v2` and `Standard_D2plds_v5` VM.
I use the A1_v2 VM on my side and it works. For the ARM image, I have an issue with it right now when we create the VM image as the VM image don't have the arch parameter, Azure try to create an amd64 image instead of an arm64 image.

Also, you can't use the Spot instance pricing with the B* VM series.

Why I add the Spot pricing? because the A1_V2 VM price is almost the same (3.14$/month) as the B1ls VM (3.80$/month) with 1 full vPCU and 2 G of memory and, normally, a better network throughput.

And the D2plds_v5 is5.6$/month with 2vCPU and 4G of memory with a far better bandwidth.

## Add a delay of 180s before removing an unused IP
Actually, we have a race condition, when we create a deployment, Azure will create the public IP first, then a NIC and, at the end, the VM. But, in the same time, if scrapoxy do a `listProxy`, it will delete unused resources like public IP and NIC. That why we add a 180s delay before a resource is deleted.
